### PR TITLE
Added symbol function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,23 @@ Drop the `{{ svgi }}` tag anywhere your heart desires.
  - __alt__: Alt text (only used for `<img>`)
  
 ##Theme Function
-__NEW!__ Link to SVGs used in your theme quicker using the `{{ svgi:theme }}` syntax. The theme function assumes a base path of the current theme when building out the URL to the SVG file. Example:
+Link to SVGs used in your theme quicker using the `{{ svgi:theme }}` syntax. The theme function assumes a base path of the current theme when building out the URL to the SVG file. Example:
 ```
 {{ svgi src="assets/img/logo.svg" }}
 Grabs file from SITEROOT/assets/img/logo.svg
  
 {{ svgi:theme src="img/logo.svg" }}
 Grabs file from SITEROOT/_themes/mytheme/img/logo.svg
+```
+
+##Symbol Function
+__NEW!__ Link to SVG symbols as defined in a file earlier in the page.  
+See the [article on CSS Tricks](http://css-tricks.com/svg-sprites-use-better-icon-fonts/) for more information. 
+Example:
+```
+{{ svgi:symbol name="menu" class="icon" }}
+
+Outputs: <svg class="icon menu"><use xlink:href="#menu"></use></svg>
 ```
  
 ##TODO

--- a/pi.svgi.php
+++ b/pi.svgi.php
@@ -137,4 +137,23 @@ class Plugin_svgi extends Plugin
         return $html;
         
     }
+
+    /**
+     * symbol function
+     *
+     * This outputs a SVG symbol reference.
+     * @see http://css-tricks.com/svg-sprites-use-better-icon-fonts/
+     *
+     * @return string
+     */
+    public function symbol()
+    {
+        $symbol = $this->fetchParam('name', null, null, false, false);
+        $class = $this->fetchParam('class', $symbol, null, false, false);
+
+        // Prevent symbol being output twice in the tag
+        $class = ($symbol === $class) ? '' : $class;
+
+        return "<svg class=\"$class $symbol\"><use xlink:href=\"#$symbol\"></use></svg>";
+    }
 }

--- a/pi.svgi.php
+++ b/pi.svgi.php
@@ -149,10 +149,7 @@ class Plugin_svgi extends Plugin
     public function symbol()
     {
         $symbol = $this->fetchParam('name', null, null, false, false);
-        $class = $this->fetchParam('class', $symbol, null, false, false);
-
-        // Prevent symbol being output twice in the tag
-        $class = ($symbol === $class) ? '' : $class;
+        $class = $this->fetchParam('class', false, null, false, false);
 
         return "<svg class=\"$class $symbol\"><use xlink:href=\"#$symbol\"></use></svg>";
     }


### PR DESCRIPTION
There's a technique I like to use – SVG Sprites – which involves one single SVG file that contains lots of SVG definitions inside it. You can then just reference the symbol instead of embedding another whole SVG file.

The tag I added is just a wrapper for it.

Let me know what you think.
