### PR TITLE
Add as="svg_image" and other small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Drop the `{{ svgi }}` tag anywhere your heart desires.
 ##Parameters
 `{{ svgi }}` accepts the following parameters:
  - __src__: Path to the SVG file (required)
- - __as__: Optionally insert SVG as `<object>` or `<img>`
+ - __as__: Optionally insert SVG into the page with different techniques:
+   - `object`
+   - `img`
+   - `svg_img` (`svg` tag with `image` fallback, see [usage](http://lynn.ru/examples/svg/en.html))
  - __alt__: Alt text (only used for `<img>`)
+ - __fallback__: Fallback image (only used for `svg_img`)
  
 ##Theme Function
 Link to SVGs used in your theme quicker using the `{{ svgi:theme }}` syntax. The theme function assumes a base path of the current theme when building out the URL to the SVG file. Example:

--- a/pi.svgi.php
+++ b/pi.svgi.php
@@ -123,14 +123,14 @@ class Plugin_svgi extends Plugin
             if ($alt)
             {
                 $alt = ' alt="' . $alt . '" ';
-            }
-            // Build <img> tag
-            $html = '<img src ="' . $full_url . '" ' . $alt . '>';
-        }
-        elseif ( $as == "obj" || $as == "object" )
-        {
-            // Build <object> tag
-            $html = '<object type="image/svg+xml" data="' . $full_url . '"></object>';
+            } 
+            // Build <img> tag                   
+            $html = '<img src ="' . $full_url . '" ' . $alt . '>';        
+        } 
+        elseif ( $as == "obj" || $as == "object" ) 
+        {            
+            // Build <object> tag                   
+            $html = '<object type="image/svg+xml" data="' . $full_url . '"></object>';   
         }
         elseif ( $as == "svg_image" )
         {

--- a/pi.svgi.php
+++ b/pi.svgi.php
@@ -57,7 +57,8 @@ class Plugin_svgi extends Plugin
         $src = $this->fetchParam('src', false, null, false, false);
         $as  = $this->fetchParam('as', false, null, false, true);
         $alt = $this->fetchParam('alt', false, null, false, false);
-		
+        $fallback = $this->fetchParam('fallback', null, null, false, false);
+
         // Exit if no $src
         if (!$src)
         {
@@ -65,13 +66,19 @@ class Plugin_svgi extends Plugin
         }
 		
         // Get theme path from global config
-        $theme_path = Config::getCurrentthemePath();
-        
+        $theme_path = Config::getCurrentThemePath();
+
         // Build new $src URL
         $src = $theme_path . $src;
 
-        return $this->insertSvg($src, $as, $alt);
-        
+        // Same for fallback
+        if ($fallback)
+        {
+            $fallback = $theme_path . $fallback;
+        }
+
+        return $this->insertSvg($src, $as, $alt, $fallback);
+
     }
 
     /**
@@ -83,10 +90,11 @@ class Plugin_svgi extends Plugin
      * @param string $src URL for file
      * @param string $as optionally insert as <object> or <img>
      * @param string $alt alt text for <img> tags only
+     * @param string $fallback fallback url for <image> tag
      * @return string
      */
-    private function insertSvg($src, $as = NULL, $alt = NULL)
-    {        
+    private function insertSvg($src, $as = NULL, $alt = NULL, $fallback = NULL)
+    {
         // Exit if no $src
         if (!$src)
         {
@@ -97,8 +105,14 @@ class Plugin_svgi extends Plugin
         $full_src = Path::assemble(BASE_PATH, $src);
         
         // Assemble URL to SVG file
-        $full_url = Config::getSiteRoot() . $src;
-        
+        $full_url = URL::prependSiteRoot($src);
+
+        // Do the same to the fallback
+        if ($fallback)
+        {
+            $full_fallback_url = URL::prependSiteRoot($fallback);
+        }
+
         // Declare return variable
         $html;
         
@@ -109,14 +123,20 @@ class Plugin_svgi extends Plugin
             if ($alt)
             {
                 $alt = ' alt="' . $alt . '" ';
-            } 
-            // Build <img> tag                   
-            $html = '<img src ="' . $full_url . '" ' . $alt . '>';        
-        } 
-        elseif ( $as == "obj" || $as == "object" ) 
-        {            
-            // Build <object> tag                   
-            $html = '<object type="image/svg+xml" data="' . $full_url . '"></object>';            
+            }
+            // Build <img> tag
+            $html = '<img src ="' . $full_url . '" ' . $alt . '>';
+        }
+        elseif ( $as == "obj" || $as == "object" )
+        {
+            // Build <object> tag
+            $html = '<object type="image/svg+xml" data="' . $full_url . '"></object>';
+        }
+        elseif ( $as == "svg_image" )
+        {
+            // Build <svg> tag
+            // see: http://lynn.ru/examples/svg/en.html for intended usage
+            $html = '<svg><image xlink:href="' . $full_url . '" src="' . $full_fallback_url . '" width="100%" height="100%" /></svg>';
         }
         else
         {


### PR DESCRIPTION
Hi Ray

This adds support for this awesome technique:
http://lynn.ru/examples/svg/en.html

It lets you do this:

```
{{ svgi:theme as="svg_img" src="img/logo.svg" fallback="img/logo.png" }}
```

``` html
<svg>
  <image 
    xlink:href="/_themes/acadia/img/logo.svg" 
    src="/_themes/acadia/img/logo.png" 
    width="100%" height="100%" />
</svg>
```

Browsers that support svg will use it, but browsers that don't will use the `src` attribute on `image` (which every browser translates to `img`)

You can then use CSS to style the size of the `svg` tag.
### Other

This PR also fixes a couple of small things:
- Fixed casing on `getCurrentthemePath`
- Use `URL::prependSiteRoot` to prevent double slashes when your theme folder is the root.
